### PR TITLE
Worked on a HTB 'Analytics' machine Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ubuntu OverlayFS Local Privesc
 
 ## Affected Versions
 
+- Ubuntu 22.04
 - Ubuntu 20.10
 - Ubuntu 20.04 LTS
 - Ubuntu 19.04


### PR DESCRIPTION
The original README.md stated that the exploit works up to Ubuntu 20. However, in this HackTheBox  [writeup,](https://medium.com/@hachikohax/analytics-htb-writeup-cracking-the-code-3344c5c05b63) it was demonstrated that the OverlayFS exploit, originally not listed for Ubuntu 22.04, successfully worked on that version as well. This update modifies the README.md to reflect that the exploit is also applicable to Ubuntu 22.04, expanding the compatibility range and providing more accurate information for users. It did work for me as I tried it too.